### PR TITLE
Feat db migration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'sinatra'
+gem 'sinatra-contrib'
 gem 'mysql2'
 gem 'sqlite3'
 gem 'nokogiri'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'sinatra'
+gem 'mysql2'
 gem 'sqlite3'
 gem 'nokogiri'
 gem 'rufus-scheduler'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,7 @@ GEM
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
     arel (7.1.4)
+    backports (3.8.0)
     bloomfilter-rb (2.1.1)
       redis
     concurrent-ruby (1.0.4)
@@ -52,6 +53,7 @@ GEM
       nokogiri (~> 1.6)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
+    multi_json (1.12.1)
     multipart-post (2.0.0)
     mysql2 (0.4.5)
     nesty (1.0.2)
@@ -65,6 +67,8 @@ GEM
     rack (1.6.4)
     rack-protection (1.5.3)
       rack
+    rack-test (0.6.3)
+      rack (>= 1.0)
     redis (3.3.1)
     rufus-scheduler (3.2.1)
     rumoji (0.5.0)
@@ -75,6 +79,13 @@ GEM
     sinatra (1.4.7)
       rack (~> 1.5)
       rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    sinatra-contrib (1.4.7)
+      backports (>= 2.0)
+      multi_json
+      rack-protection
+      rack-test
+      sinatra (~> 1.4.0)
       tilt (>= 1.3, < 3)
     sqlite3 (1.3.11)
     thread_safe (0.3.5)
@@ -99,6 +110,7 @@ DEPENDENCIES
   rumoji
   sanitize
   sinatra
+  sinatra-contrib
   sqlite3
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,7 @@ GEM
     mini_portile2 (2.1.0)
     minitest (5.10.1)
     multipart-post (2.0.0)
+    mysql2 (0.4.5)
     nesty (1.0.2)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
@@ -92,6 +93,7 @@ DEPENDENCIES
   activerecord
   highscore
   metainspector
+  mysql2
   nokogiri
   rufus-scheduler
   rumoji

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,0 +1,10 @@
+development:
+  db_adapter: 'sqlite3'
+  db_database: 'news.db'
+
+production:
+  db_adapter: 'mysql2'
+  db_host: 'localhost'
+  db_username: 'root'
+  db_password: ''
+  db_database: 'canillitapp'

--- a/database.rb
+++ b/database.rb
@@ -14,7 +14,7 @@ require 'active_record'
 ActiveRecord::Base.establish_connection(
   adapter: 'mysql2',
   host: 'localhost',
-  username: 'root',
-  password: '',
+  username: 'betzerra',
+  password: 'corsa0gris1',
   database: 'canillitapp'
 )

--- a/database.rb
+++ b/database.rb
@@ -3,8 +3,18 @@ require 'active_record'
 # Uncomment this if you want to log some database issue
 # ActiveRecord::Base.logger = Logger.new(File.open('database.log', 'w'))
 
+# SQLITE development db
+# ActiveRecord::Base.establish_connection(
+#   :adapter  => 'sqlite3',
+#   :database => 'news.db',
+#   :pool => 30
+# )
+
+# MySQL production db
 ActiveRecord::Base.establish_connection(
-  :adapter  => 'sqlite3',
-  :database => 'news.db',
-  :pool => 30
+  adapter: 'mysql2',
+  host: 'localhost',
+  username: 'root',
+  password: '',
+  database: 'canillitapp'
 )

--- a/database.rb
+++ b/database.rb
@@ -1,20 +1,24 @@
 require 'active_record'
+require 'sinatra'
+require 'sinatra/config_file'
+
+config_file 'config/config.yml'
+
+if settings.db_adapter == 'sqlite3' then
+  ActiveRecord::Base.establish_connection(
+  adapter: settings.db_adapter,
+  database: settings.db_database,
+  pool: 30
+)
+else
+  ActiveRecord::Base.establish_connection(
+  adapter: settings.db_adapter,
+  host: settings.db_host,
+  username: settings.db_username,
+  password: settings.db_password,
+  database: settings.db_database
+)
+end
 
 # Uncomment this if you want to log some database issue
 # ActiveRecord::Base.logger = Logger.new(File.open('database.log', 'w'))
-
-# SQLITE development db
-# ActiveRecord::Base.establish_connection(
-#   :adapter  => 'sqlite3',
-#   :database => 'news.db',
-#   :pool => 30
-# )
-
-# MySQL production db
-ActiveRecord::Base.establish_connection(
-  adapter: 'mysql2',
-  host: 'localhost',
-  username: 'betzerra',
-  password: 'corsa0gris1',
-  database: 'canillitapp'
-)

--- a/news.rb
+++ b/news.rb
@@ -7,7 +7,7 @@ class News < ActiveRecord::Base
   delegate :name, :to => :source, :prefix => true
 
   def self.search_news_by_title(search)
-    News.where('title LIKE ?', "%#{search}%").order('date DESC').limit(200)
+    News.where('LOWER(title) LIKE ?', "%#{search.downcase}%").order('date DESC').limit(200)
   end
 
   def self.search_news_by_title_with_reactions(search)

--- a/run.eye
+++ b/run.eye
@@ -10,7 +10,7 @@ Eye.application 'canillitapp' do
   
   process :canillitapp_server do
     pid_file 'canillitapp_server.pid' # pid_path will be expanded with the working_dir
-      start_command 'bundle exec rackup -p4567 --host 0.0.0.0'
+      start_command 'bundle exec rackup -p4567 --host 0.0.0.0 -E development'
 
       # when no stop_command or stop_signals, default stop is [:TERM, 0.5, :KILL]
       # default `restart` command is `stop; start`
@@ -20,5 +20,12 @@ Eye.application 'canillitapp' do
 
       # ensure the CPU is below 30% at least 3 out of the last 5 times checked
       check :cpu, below: 70, times: [3, 5]
-    end
+  end
+  
+  process :canillitapp_news_fetcher do
+    pid_file 'canillitapp_fetch_news.pid'
+      start_command 'ruby fetcher_job.rb'
+      daemonize true
+      stdall 'canillitapp_fetch_news.log'
+  end
 end


### PR DESCRIPTION
- Use `config.yml` to handle configurations instead of hardcoded setup in database.rb
- Add _canillitapp_news_fetcher_ as a process in `run.eye` instead of running it with nohup