### PR TITLE
Fix fetcher

### DIFF
--- a/fetcher_job.rb
+++ b/fetcher_job.rb
@@ -5,7 +5,7 @@ news = NewsFetcher.new
 
 scheduler = Rufus::Scheduler.new
 
-scheduler.every '10m', first_in: '3s', overlap: false do
+scheduler.every '30m', first_in: '3s', overlap: false do
   news.fetch
 end
 


### PR DESCRIPTION
- [x] fetcher job runs less often since now takes longer (more sources + task is more complex now)
- [x] avoids duplicates on Infobae.
- [x] finding a duplicate doesn't break the loop. This allows finding more news on a different RSS category.