### PR TITLE
fix: infobae news from other papers

### DIFF
--- a/fetcher.rb
+++ b/fetcher.rb
@@ -74,8 +74,8 @@ class NewsFetcher
 
           # this matches every title with "xx de <month> de <year>" commonly
           # used for quoting news from other newspapers on Infobae
-          news_from_other_papers_reges = regex = /.+[0-9]+\sde\s(\bEnero\b|\bFebrero\b|\bMarzo\b|\bAbril\b|\bMayo\b|\bJunio\b|\bJulio\b|\bAgosto\b|\bSeptiembre\b|\bOctubre\b|\bNoviembre\b|\bDiciembre\b)\sde\s[0-9]+/i
-          if title.match(regex) && source['name'] == 'Infobae'
+          news_from_other_papers_regex = /.+[0-9]+\sde\s(Enero|Febrero|Marzo|Abril|Mayo|Junio|Julio|Agosto|Septiembre|Octubre|Noviembre|Diciembre)\sde\s[0-9]+/i
+          if title.match(news_from_other_papers_regex) && source['name'] == 'Infobae'
             @logger.debug("Skipping #{title}")
             next
           end

--- a/fetcher.rb
+++ b/fetcher.rb
@@ -72,6 +72,14 @@ class NewsFetcher
           date = NewsFetcher.date_from_news(item)
           date = DateTime.now.strftime('%s') if date.nil?
 
+          # this matches every title with "xx de <month> de <year>" commonly
+          # used for quoting news from other newspapers on Infobae
+          news_from_other_papers_reges = regex = /.+[0-9]+\sde\s(\bEnero\b|\bFebrero\b|\bMarzo\b|\bAbril\b|\bMayo\b|\bJunio\b|\bJulio\b|\bAgosto\b|\bSeptiembre\b|\bOctubre\b|\bNoviembre\b|\bDiciembre\b)\sde\s[0-9]+/i
+          if title.match(regex) && source['name'] == 'Infobae'
+            @logger.debug("Skipping #{title}")
+            next
+          end
+
           ActiveRecord::Base.connection_pool.with_connection do
             news = News.create(
               url: link_url,

--- a/labs/infobae_filter.rb
+++ b/labs/infobae_filter.rb
@@ -1,0 +1,10 @@
+require File.expand_path(File.dirname(__FILE__) + '/../news.rb')
+require File.expand_path(File.dirname(__FILE__) + '/../tag.rb')
+
+regex = /.+[0-9]+\sde\s(\bEnero\b|\bFebrero\b|\bMarzo\b|\bAbril\b|\bMayo\b|\bJunio\b|\bJulio\b|\bAgosto\b|\bSeptiembre\b|\bOctubre\b|\bNoviembre\b|\bDiciembre\b)\sde\s[0-9]+/i
+
+News.all.each do |i|
+  if match = i.title.match(regex)
+    puts "#{i.source_name} - #{i.title}"
+  end
+end

--- a/labs/infobae_filter.rb
+++ b/labs/infobae_filter.rb
@@ -1,7 +1,7 @@
 require File.expand_path(File.dirname(__FILE__) + '/../news.rb')
 require File.expand_path(File.dirname(__FILE__) + '/../tag.rb')
 
-regex = /.+[0-9]+\sde\s(\bEnero\b|\bFebrero\b|\bMarzo\b|\bAbril\b|\bMayo\b|\bJunio\b|\bJulio\b|\bAgosto\b|\bSeptiembre\b|\bOctubre\b|\bNoviembre\b|\bDiciembre\b)\sde\s[0-9]+/i
+regex = /.+[0-9]+\sde\s(Enero|Febrero|Marzo|Abril|Mayo|Junio|Julio|Agosto|Septiembre|Octubre|Noviembre|Diciembre)\sde\s[0-9]+/i
 
 News.all.each do |i|
   if match = i.title.match(regex)


### PR DESCRIPTION
matches and ignores every title with _"<something>, xx de <month> de <year>"_ commonly used for quoting news from other newspapers on **Infobae**.

NOTE: This only ignores that kind of titles on Infobae.